### PR TITLE
patch oppgradere kotlin og spring-boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>no.nav.historisk</groupId>
@@ -18,8 +18,7 @@
     <properties>
         <revision>0.0.1-SNAPSHOT</revision>
         <java.version>25</java.version>
-        <!-- CodeQL har problemer med for nye kotlin versjoner https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/ -->
-        <kotlin.version>2.3.0</kotlin.version>
+        <kotlin.version>2.3.20</kotlin.version>
         <springdoc.version>3.0.3</springdoc.version>
     </properties>
     <modules>


### PR DESCRIPTION
Oppgraderer kotlin til versjon 2.3.20 siden CodeQL nå støtter den versjonen. Oppgraderer også spring-boot til siste versjon, som er 4.0.6.