### PR TITLE
patch tomcat 11.0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,27 @@
         <module>backend</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Pin Tomcat embed modules to 11.0.22 to fix CVE-2026-41293 (CRITICAL) from spring-boot-starter-webmvc -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>11.0.22</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>11.0.22</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>11.0.22</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Pin Tomcat embed modules to 11.0.22 to fix CVE-2026-41293 (CRITICAL) from spring-boot-starter-webmvc